### PR TITLE
feat: add support for rdfs:Datatype to ClosedOntologyNamespace

### DIFF
--- a/lodkit/namespace_tools/ontology_namespace.py
+++ b/lodkit/namespace_tools/ontology_namespace.py
@@ -1,8 +1,9 @@
 from types import MappingProxyType
 
-from lodkit.types import GraphParseSource
 from rdflib import Graph, URIRef
 from rdflib.query import Result
+
+from lodkit.types import GraphParseSource
 
 
 class NoSolutionException(Exception): ...
@@ -44,6 +45,8 @@ class ClosedOntologyNamespace:
     values ?type {
       rdfs:Class
       owl:Class
+
+      rdfs:Datatype
 
       rdf:Property
       owl:ObjectProperty

--- a/tests/test_namespace_tools/test_closed_ontology_namespace.py
+++ b/tests/test_namespace_tools/test_closed_ontology_namespace.py
@@ -1,9 +1,9 @@
 """Pytest entry point for ClosedOntologyNamespace tests."""
 
 import pytest
+from rdflib import RDF, RDFS, Graph, URIRef
 
 from lodkit import ClosedOntologyNamespace, NoSolutionException
-from rdflib import Graph, RDF, RDFS, URIRef
 
 
 def test_closed_ns_term_types():
@@ -24,6 +24,8 @@ def test_closed_ns_term_types():
     <urn:owl_annotationproperty> a owl:AnnotationProperty .
 
     <urn:owl_namedindividual> a owl:NamedIndividual .
+    
+    <urn:rdfs_datatype> a rdfs:Datatype .
     """
 
     g = Graph().parse(data=data, format="ttl")
@@ -37,6 +39,7 @@ def test_closed_ns_term_types():
         "owl_datatypeproperty": URIRef("urn:owl_datatypeproperty"),
         "owl_annotationproperty": URIRef("urn:owl_annotationproperty"),
         "owl_namedindividual": URIRef("urn:owl_namedindividual"),
+        "rdfs_datatype": URIRef("urn:rdfs_datatype"),
     }
 
     assert ns.mapping == expected


### PR DESCRIPTION
The change adds support for `rdfs:Datatype` to `ClosedOntologyNamespace`, i.e. the SPARQL query powering `Closedontologynamespace` now also looks for and ergo registers `rdfs:Datatype` in the constructed namespace.

Closes #68.